### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 		<ez.org.slf4j.version>1.7.12</ez.org.slf4j.version>
 		<ez.junit.version>4.4</ez.junit.version>
 		<ez.commons-lang.version>3.4</ez.commons-lang.version>
-		<ez.commons-collections.version>3.2.1</ez.commons-collections.version>
+		<ez.commons-collections.version>3.2.2</ez.commons-collections.version>
 	</properties>
 
 	<scm>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
